### PR TITLE
Add LSP support for C source files

### DIFF
--- a/bundles/codyze-eclipse-plugin/plugin.xml
+++ b/bundles/codyze-eclipse-plugin/plugin.xml
@@ -53,10 +53,19 @@
    </extension>
    
    <extension
+         id="javaSource"
          point="org.eclipse.core.filebuffers.documentSetup">
       <participant
             class="org.eclipse.lsp4e.ConnectDocumentToLanguageServerSetupParticipant"
             contentTypeId="org.eclipse.jdt.core.javaSource">
+      </participant>
+   </extension>
+   <extension
+         id="CSource"
+         point="org.eclipse.core.filebuffers.documentSetup">
+      <participant
+            class="org.eclipse.lsp4e.ConnectDocumentToLanguageServerSetupParticipant"
+            contentTypeId="org.eclipse.cdt.core.cSource">
       </participant>
    </extension>
 </plugin>


### PR DESCRIPTION
This registers C source files with the LSP server. It allows to analyze C source files. It triggers LSP methods necessary to instruct Codyze to analyze the source file.